### PR TITLE
Restrict ChequesView access for vendors

### DIFF
--- a/src/components/ChequesView.tsx
+++ b/src/components/ChequesView.tsx
@@ -34,6 +34,9 @@ interface ChequesViewProps {
 }
 
 export const ChequesView: React.FC<ChequesViewProps> = ({ currentUser }) => {
+  if (currentUser.rol?.toLowerCase() !== 'admin') {
+    return <p>Acceso denegado</p>
+  }
   const [cheques, setCheques] = useState<Cheque[]>([])
   const [clientes, setClientes] = useState<any[]>([])
   const [loading, setLoading] = useState(true)

--- a/src/components/__tests__/ChequesView.test.tsx
+++ b/src/components/__tests__/ChequesView.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { ChequesView } from '../ChequesView'
+
+describe('ChequesView access control', () => {
+  it('denies access to vendors', () => {
+    const currentUser = { id: 1, nombre: 'Vendedor', rol: 'vendedor' }
+    render(<ChequesView currentUser={currentUser} />)
+    expect(screen.getByText(/Acceso denegado/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- block non-admin roles from `ChequesView`
- test that vendors see an "Acceso denegado" message

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e981fa75c832ea443d2637d4b0662