### PR TITLE
Update ChequesView to use shared CurrentUser type

### DIFF
--- a/src/components/ChequesView.tsx
+++ b/src/components/ChequesView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { Plus, Edit, Trash2, Calendar, DollarSign, User, FileText, Download } from 'lucide-react'
 import { supabase, formatearMoneda, formatearFecha } from '../lib/supabase'
+import { CurrentUser } from '../store/session'
 
 interface Cheque {
   id: number
@@ -30,7 +31,7 @@ interface FormularioCheque {
 }
 
 interface ChequesViewProps {
-  currentUser: { id: number; nombre: string; rol: string }
+  currentUser: CurrentUser
 }
 
 export const ChequesView: React.FC<ChequesViewProps> = ({ currentUser }) => {


### PR DESCRIPTION
## Summary
- import `CurrentUser` in `ChequesView`
- use `CurrentUser` for `currentUser` prop type

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9f146380832ea722d979de96d793